### PR TITLE
Adding getMockObject() to TestCase

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 UA1 Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Release Changes
+* 2.2.0
+    * Added capability to mock classes for tests.
+    * Added LICENSE
 * 2.1.0
     * Updating code formatting to be PSR-2 compliant
 * 2.0.0

--- a/UA1Labs/Fire/Test/TestCase.TestCase.php
+++ b/UA1Labs/Fire/Test/TestCase.TestCase.php
@@ -15,6 +15,7 @@
 namespace Test\UA1Labs\Fire\Test;
 
 use \UA1Labs\Fire\Test\TestCase;
+use \UA1Labs\Fire\TestException;
 
 class TestCaseTestCase extends TestCase
 {
@@ -35,6 +36,22 @@ class TestCaseTestCase extends TestCase
     {
         $this->should('Return an instance object of the TestCase object without throwing an exception.');
         $this->assert($this->testCase instanceof TestCase);
+    }
+
+    public function testGetMock()
+    {
+        $this->should('Throw an exception if the class we are trying to mock does not exists');
+        try {
+            $mock = $this->testCase->getMockObject('Mock');
+            $this->assert(false);
+        } catch (TestException $e) {
+            $this->assert(true);
+        }
+
+        $this->should('Return an empty object of the type we requested.');
+        $mock = $this->testCase->getMockObject(TestCaseMock::class);
+        var_dump($mock);
+        exit();
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ua1-labs/firetest",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "A Lightweight PHP Testing Framework",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
In this pull request, I'm adding Object Mocking functionality to test cases to allow developers testing their code to get a blank object that extends the object you are requesting to mock. In the mocking process, all public methods are overriden.